### PR TITLE
Remove Warnings from Widget Page

### DIFF
--- a/enhanced-text-widget.php
+++ b/enhanced-text-widget.php
@@ -74,11 +74,26 @@ class EnhancedTextWidget extends WP_Widget {
 
     function form( $instance ) {
         $instance = wp_parse_args( (array) $instance, array( 'title' => '', 'titleUrl' => '', 'text' => '' ) );
-        $title = strip_tags($instance['title']);
-        $titleUrl = strip_tags($instance['titleUrl']);
-        $newWindow = $instance['newWindow'] ? 'checked="checked"' : '';
-        $cssClass = strip_tags($instance['cssClass']);
-        $text = format_to_edit($instance['text']);
+        $title = "";
+        if(isset($instance['title'])){
+            $title = strip_tags($instance['title']);
+        }
+        $titleUrl = "";
+        if(isset($instance['titleUrl'])){
+            $titleUrl = strip_tags($instance['titleUrl']);
+        }
+        $newWindow = "";
+        if(isset($instance['newWindow'])){
+            $newWindow = 'checked="checked"';
+        }
+        $cssClass = "";
+        if(isset($instance['cssClass'])){
+            $cssClass = strip_tags($instance['cssClass']);
+        }
+        $text = "";
+        if(isset($instance['text'])){
+            $text = format_to_edit($instance['text']);
+        }
 ?>
         <p><label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:'); ?></label>
         <input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></p>


### PR DESCRIPTION
I added some code to check for array indicies before accessing them. This should close issue #3.
